### PR TITLE
Support Laravel 12 and drop support for laravel 9

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -4,16 +4,18 @@ on: [ push ]
 
 jobs:
   tests:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: true
       matrix:
-        php: [8.1, 8.2, 8.3, 8.4]
-        laravel: [10, 11]
+        php: [ 8.1, 8.2, 8.3, 8.4 ]
+        laravel: [ 10, 11, 12 ]
         exclude:
           - php: 8.1
             laravel: 11
+          - php: 8.1
+            laravel: 12
           - php: 8.4
             laravel: 10
 

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": "^8.1",
         "ext-json": "*",
-        "illuminate/auth": "^9.21|^10.0|^11.0",
+        "illuminate/auth": "^10.0|^11.0|^12.0",
         "guzzlehttp/guzzle": "^6.4 || ^7.0",
         "psr/log": "^1.1 || ^2.0 || ^3.0",
         "nesbot/carbon": "^2.26 || ^3.0",
@@ -32,8 +32,8 @@
         "league/oauth2-client": "^2.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.1 || ^10.0 || ^11.0",
-        "orchestra/testbench": "^7.35|^8.14|^9.0",
+        "phpunit/phpunit": "^10.0 || ^11.0 || ^12.0",
+        "orchestra/testbench": "^8.14|^9.0|^10.0",
         "phpspec/prophecy-phpunit": "^2.0"
     },
     "autoload": {


### PR DESCRIPTION
### TL;DR
Added Laravel 12 support and updated dependency requirements.

### What changed?
- Added Laravel 12 to the test matrix
- Excluded PHP 8.1 from Laravel 12 tests
- Updated `illuminate/auth` to support Laravel 12
- Updated PHPUnit requirements to `^10.0 || ^11.0 || ^12.0`
- Updated Orchestra Testbench to include version 10 support
- Removed Laravel 9 support from dependencies

### How to test?
1. Run the test suite with different PHP and Laravel version combinations
2. Verify the CI pipeline passes for all supported version combinations
3. Test package functionality with Laravel 12 specifically

### Why make this change?
To ensure compatibility with the upcoming Laravel 12 release while maintaining support for existing Laravel versions. This change prepares the package for future Laravel releases and keeps it up to date with the latest framework developments.